### PR TITLE
Remove cache feature to remove indirection

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,12 +148,6 @@ window.setInterval(function(){
 
 _Note: This again does not work for IE 6 & 7. They just ignore any programmatic assignment._
 
-###A note on stylesheet caching###
-
-Since the polyfill needs to re-retrieve and parse every stylesheet again I implemented localStorage caching. Contents of stylesheets that have successfully been retrieved will get stored in localStorage. On the next reload of the page the polyfill will use the stylesheet from localStorage so that it renders quicker. When that is done it will retrieve the file and replace localStorage contents. That means that when you develop you would need to refresh twice to see any changes you made regarding filters. 
-
-But to make your life easier I implemented a mechanism that looks on the hostname, and when it is "localhost" or when it uses the TLD ".local" or when it's an IP address it turns that caching off.
-
 ###Cross Origin Restrictions###
 
 If you practice domain sharding and serve your assets from a different domain than the page you have two options to solve the problem of the poylfill not being allowed to refetch the stylesheets:

--- a/lib/css-filters-polyfill.js
+++ b/lib/css-filters-polyfill.js
@@ -61,16 +61,7 @@
 		_pending_stylesheets: 0,
 	
 		_stylesheets: 		[],
-		
-		_development_mode: (function(){
-			if(location.hostname === 'localhost' || location.hostname.search(/.local$/) !== -1 || location.hostname.search(/\d+\.\d+\.\d+\.\d+/) !== -1){
-				if(window.console) console.log('Detected localhost or IP address. Assuming you are a developer. Caching of stylesheets is disabled.');
-				return true;
-			}
-			if(window.console) console.log('Caching of stylesheets is enabled. You need to refresh twice to see any changes.');
-			return false;
-		})(),
-		
+
 		process_stylesheets: function(){
 			var xmlHttp = [];
 			
@@ -120,16 +111,7 @@
 								
 								// Fetch external stylesheet
 								var href = stylesheets[i].href;
-								
-								// Use localStorage as cache for stylesheets, if available
-								if(!polyfilter._development_mode && window.localStorage && window.localStorage.getItem('polyfilter_' + href)){
-									polyfilter._pending_stylesheets--;
-									polyfilter._stylesheets[index].content = localStorage.getItem('polyfilter_' + href);
-									if(polyfilter._pending_stylesheets === 0){
-										polyfilter.process();
-									}
-								}
-	
+
 								// Always fetch stylesheets to reflect possible changes
 								try{
 									if(window.XMLHttpRequest) {
@@ -155,15 +137,6 @@
 													polyfilter._stylesheets[index].content = xmlHttp.responseText;
 													if(polyfilter._pending_stylesheets === 0){
 														polyfilter.process();
-													}
-												}
-												// Cache stylesheet in localStorage, if available
-												if(!polyfilter._development_mode && window.localStorage){
-													try{
-														window.localStorage.setItem('polyfilter_' + href,polyfilter._stylesheets[index].content)
-													}
-													catch(e){
-														if(window.console) console.log('Local storage quota have been exceeded. Caching of stylesheet ' + href + ' is not possible');
 													}
 												}
 											}


### PR DESCRIPTION
It doesn't work reliably and the double refresh adds another indirection layer, which can cause confusion. Also the parsing isn't very time consuming in my measurements.

This was the error I was getting using the caching feature in Firefox 24 on OSX:

```
[16:43:20.040] NS_ERROR_FILE_CORRUPTED: Component returned failure code: 0x8052000b 
(NS_ERROR_FILE_CORRUPTED) [nsIDOMStorage.getItem] 
@ http://example.org/v5b33fae/core/js/compat/css-filters.js:13
```
